### PR TITLE
Update assayclasses.json

### DIFF
--- a/assayclasses.json
+++ b/assayclasses.json
@@ -2146,27 +2146,6 @@
   {
     "rule_description": {
       "application_context": "HUBMAP",
-      "code": "C200970",
-      "name": "DCWG cycif"
-    },
-    "value": {
-      "active_status": "inactive",
-      "assaytype": "cycif",
-      "contains_full_genetic_sequences": false,
-      "dataset_type": "CyCIF",
-      "description": "CyCIF",
-      "dir_schema": "cycif-v2",
-      "is_multiassay": false,
-      "must_contain": [],
-      "pipeline_shorthand": null,
-      "process_state": "primary",
-      "tbl_schema": null,
-      "vitessce_hints": []
-    }
-  },
-  {
-    "rule_description": {
-      "application_context": "HUBMAP",
       "code": "C200980",
       "name": "DCWG merfish"
     },

--- a/assayclasses.json
+++ b/assayclasses.json
@@ -2918,5 +2918,31 @@
       "tbl_schema": null,
       "vitessce_hints": []
     }
-  }
+  },
+  {
+    "rule_description": {
+      "application_context": "HUBMAP",
+      "code": "C202130",
+      "name": "derived visium-with-probes"
+    },
+    "value": {
+      "active_status": "active",
+      "assaytype": "visium-with-probes",
+      "contains_full_genetic_sequences": false,
+      "dataset_type": "Visium (with probes)",
+      "description": "Visium (with probes) [Salmon + Scanpy]",
+      "dir_schema": null,
+      "is_multiassay": true,
+      "must_contain": [],
+      "pipeline_shorthand": "Salmon + Scanpy",
+      "process_state": "derived",
+      "tbl_schema": null,
+      "vitessce_hints": [
+        "spatial",
+        "anndata",
+        "is_image",
+        "rna"
+      ]
+    }
+  } 
 ]


### PR DESCRIPTION
This PR:
- Deletes entry C200970 from UBKG. It was never used for ingestion and was replaced by Thick Section MxIF.
- Adds an entry for derived visium-with-probes datasets